### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,9 @@ $scope.returnedValues = [];
 - fix displaying long names
 - fix styles for items list
 
-##Created by [BogdanRusinka](https://github.com/BogdanRusinka) 
+## Created by [BogdanRusinka](https://github.com/BogdanRusinka) 
 
-##Contributing
+## Contributing
 Feel free to open issues and send PRs. 
 
 ## License


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
